### PR TITLE
[RoF] Class Feature Variants & Cognitivist sheet description fix

### DIFF
--- a/NV/bladetide-setting/options.xml
+++ b/NV/bladetide-setting/options.xml
@@ -4,7 +4,7 @@
         <name>Options</name>
         <description>Options for Bladetide Campaigns.</description>
 		<author url="https://www.reddit.com/user/Nick_Vendel/">Nick Vendel</author>
-		<update version="0.0.3">
+		<update version="0.0.4">
 			<file name="options.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/options.xml" />
         </update>
     </info>
@@ -18,6 +18,7 @@
         </sheet>
         <rules>
             <grant type="Option" id="ID_NV_BDTD_OPTION_ATTUNEMENT" />
+            <grant type="Option" id="ID_NV_FLDS_OPTION_CLASS_FEATURE_VARIANTS" />
         </rules>
     </element>
 

--- a/NV/bladetide-setting/realm-of-fauldis.index
+++ b/NV/bladetide-setting/realm-of-fauldis.index
@@ -4,7 +4,7 @@
 		<name>Realm of Fauldis Index</name>
 		<description>The content from the Realm of Fauldis.</description>
 		<author url="https://www.reddit.com/user/Nick_Vendel/">Nick Vendel</author>
-		<update version="0.0.4">
+		<update version="0.0.5">
 			<file name="realm-of-fauldis.index" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis.index" />
 		</update>
 	</info>
@@ -37,6 +37,9 @@
 		<!-- <file name="prestige-class-shapechanger.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis/classes/prestige-class-shapechanger.xml" /> -->
 		<!-- <file name="prestige-class-titan-slayer.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis/classes/prestige-class-titan-slayer.xml" /> -->
 		<!-- <file name="prestige-class-vampire.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis/classes/prestige-class-vampire.xml" /> -->
+
+		<!-- Class Feature Variants -->
+		<file name="class-feature-variants.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis/classes/class-feature-variants.xml" />
 
 		<!-- Backgrounds -->
 		<!-- <file name="-.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis/backgrounds/-.xml" /> -->

--- a/NV/bladetide-setting/realm-of-fauldis/classes/class-feature-variants.xml
+++ b/NV/bladetide-setting/realm-of-fauldis/classes/class-feature-variants.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<name>Class Feature Variants</name>
+		<description>Class Feature Variants from the Realm of Fauldis</description>
+		<author url="https://www.reddit.com/user/Nick_Vendel/">Nick Vendel</author>
+		<update version="0.0.1">
+			<file name="class-feature-variants.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis/classes/class-feature-variants.xml" />
+		</update>
+	</info>
+
+	<!-- Option -->
+	<element name="RoF: Class Feature Variants" type="Option" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_OPTION_CLASS_FEATURE_VARIANTS">
+		<description>
+			<p>Optional class features from the Realm of Fauldis that either enhance already existing features or replace features with something new.</p>
+		</description>
+		<setters>
+			<set name="short">Class Feature Variants from the Realm of Fauldis.</set>
+		</setters>
+	</element>
+
+	<!-- Druid -->
+	<!-- Circle Spells Variants -->
+	<element name="Shadewoods Circle" type="Archetype Feature" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_CFV_ARCHETYPE_FEATURE_CIRCLE_SPELLS_SHADEWOODS">
+		<requirements>ID_NV_FLDS_OPTION_CLASS_FEATURE_VARIANTS</requirements>
+		<supports>Circle Spells</supports>
+		<description>
+			<p style="margin-bottom:5px"><i>2nd-level Circle of the Land feature (enhances Circle Spells)</i></p>
+			<p style="margin-top:0px">Unusual magical forests, whose trees are incredibly sturdy, huge and cover everything around with their shadow. Being druid of shadewoods circle you gain following spells, that count as druid spells for you,are always prepared, and do not count against the number of spells you can prepare each day:</p>
+			<table>
+				<thead>
+					<tr><td>Druid Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>3rd</td><td><em>darkness, invisibility</em></td></tr>
+				<tr><td>5th</td><td><em>spirit shroud∗, spirit guardians</em></td></tr>
+				<tr><td>7th</td><td><em>greater invisibility, shadow of moil</em></td></tr>
+				<tr><td>9th</td><td><em>dispel evil and good, far step</em></td></tr>
+			</table>
+			<p class="indent"><i>Symbol (∗) in this table refers to a spell (or spells) from <b>Unearthed Arcana 2020: Spells and Magic Tattoos</b>.</i></p>
+		</description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_DARKNESS" level="3" spellcasting="Druid" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_INVISIBILITY" level="3" spellcasting="Druid" prepared="true" />
+			<grant type="Spell" id="ID_WOTC_UA20200326_SPELL_SPIRIT_SHROUD" level="5" spellcasting="Druid" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_SPIRIT_GUARDIANS" level="5" spellcasting="Druid" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_GREATER_INVISIBILITY" level="7" spellcasting="Druid" prepared="true" />
+			<grant type="Spell" id="ID_XGTE_SPELL_SHADOW_OF_MOIL" level="7" spellcasting="Druid" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DISPEL_EVIL_AND_GOOD" level="9" spellcasting="Druid" prepared="true" />
+			<grant type="Spell" id="ID_XGTE_SPELL_FAR_STEP" level="9" spellcasting="Druid" prepared="true" />
+		</rules>
+	</element>
+
+	<!-- Wizard -->
+	<!-- Artifact Researcher -->
+	<element name="Class Feature Variant: Polyglot Replacement" type="Item" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_ITEM_CFV_WIZARD_SUBCLASS_COGNITIVIST_POLYGLOT">
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<p><i>2nd-level Cognitivist feature (replaces Polyglot)</i></p>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="slot">misc</set>
+		</setters>
+		<rules>
+			<grant type="Grants" id="ID_NV_FLDS_CFV_WIZARD_SUBCLASS_COGNITIVIST_POLYGLOT" requirements="ID_NV_FLDS_OPTION_CLASS_FEATURE_VARIANTS" />
+			<select type="Archetype Feature" name="Polyglot Replacement" supports="CFV Polyglot" requirements="ID_NV_FLDS_OPTION_CLASS_FEATURE_VARIANTS" optional="true" />
+		</rules>
+	</element>
+
+	<element name="Polyglot Replacement" type="Grants" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_CFV_WIZARD_SUBCLASS_COGNITIVIST_POLYGLOT" />
+
+	<element name="Artifact Researcher" type="Archetype Feature" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_CFV_WIZARD_SUBCLASS_COGNITIVIST_ARTIFACT_RESEARCHER">
+		<supports>CFV Polyglot</supports>
+		<description>
+			<p style="margin-bottom:5px"><i>2nd-level Cognitivist feature (replaces Polyglot)</i></p>
+			<p style="margin-top:0px">You've read enough books of ancient lore and historical notes to easily distinguish truly valuable items from fakes, especially when it comes to magical items. When you touch an item, you can use your action to study the object and discover its functions, similar to the effects of <i>identify</i> spell, you also gain knowledge on approximate cost of the object.</p>
+			<p class="indent">You can use this ability number of times equal to your Intelligence modifier (minimum of 1) after each long rest.</p>
+		</description>
+		<sheet action="Action" usage="{{artifact researcher:usage}}/Long Rest">
+			<description>When you touch an item, you can use your action to study the object and discover its functions, similar to the effects of identify spell, you also gain knowledge on approximate cost of the object.</description>
+		</sheet>
+		<rules>
+			<stat name="artifact researcher:usage" value="1" bonus="base" />
+			<stat name="artifact researcher:usage" value="intelligence:modifier" bonus="base" />
+		</rules>
+	</element>
+
+</elements>

--- a/NV/bladetide-setting/realm-of-fauldis/classes/class-feature-variants.xml
+++ b/NV/bladetide-setting/realm-of-fauldis/classes/class-feature-variants.xml
@@ -54,6 +54,7 @@
 	<!-- Wizard -->
 	<!-- Artifact Researcher -->
 	<element name="Class Feature Variant: Polyglot Replacement" type="Item" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_ITEM_CFV_WIZARD_SUBCLASS_COGNITIVIST_POLYGLOT">
+		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
 			<p><i>2nd-level Cognitivist feature (replaces Polyglot)</i></p>
@@ -68,7 +69,9 @@
 		</rules>
 	</element>
 
-	<element name="Polyglot Replacement" type="Grants" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_CFV_WIZARD_SUBCLASS_COGNITIVIST_POLYGLOT" />
+	<element name="Polyglot Replacement" type="Grants" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_CFV_WIZARD_SUBCLASS_COGNITIVIST_POLYGLOT">
+		<compendium display="false" />
+	</element>
 
 	<element name="Artifact Researcher" type="Archetype Feature" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_CFV_WIZARD_SUBCLASS_COGNITIVIST_ARTIFACT_RESEARCHER">
 		<supports>CFV Polyglot</supports>

--- a/NV/bladetide-setting/realm-of-fauldis/classes/wizard-subclass-cognitivist.xml
+++ b/NV/bladetide-setting/realm-of-fauldis/classes/wizard-subclass-cognitivist.xml
@@ -153,22 +153,22 @@
 			<p class="indent">These benefits last 1 hour, unless specified otherwise. Once you use this ability you need to finish short or long rest, before using it again.</p>
 		</description>
 		<sheet action="1 Minute" usage="1/Rest">
-			<description><![CDATA[You and number of your allies equal to {{secrets of the bestiary:allies}}, that can hear you, gain one benefit that you choose from the following list: <br />
-			&nbsp;&nbsp;• Aberration – one time you fail a saving throw forced upon you by an Aberration, you can choose to succeed instead, if not used you lose this ability after 1 hour; <br />
-			&nbsp;&nbsp;• Beast – you gain advantage on saving throws against being poisoned, knocked prone or grappled which forced upon you by a Beast creature; <br />
-			&nbsp;&nbsp;• Celestial – your spells and magical abilities ignore Magical Resistance trait of Celestial creatures, or when you hit Celestial creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; <br />
-			&nbsp;&nbsp;• Construct – when dealing damage to Constructs you ignore their resistances and immunities to bludgeoning, piercing, and slashing damage; <br />
-			&nbsp;&nbsp;• Dragon – one time, whenever you fail a saving throw forced upon you by Breath (or any other Rechargeable) action of a Dragon creature, you can choose to succeed instead, if not used you lose this ability after 1 hour. Additionally, you gain advantage on saving throws against Frightful Presence; <br />
-			&nbsp;&nbsp;• Elemental – when you deal damage to an Elemental, you ignore their resistances to acid, cold, fire, lightning, poison or thunder damage types, and you treat immunities to those types of damage as resistances; <br />
-			&nbsp;&nbsp;• Fey – You gain advantage on any Wisdom or Intelligence saving throw forced upon you by a Fey creature; <br />
-			&nbsp;&nbsp;• Fiend – Your spells and magical abilities ignore Magical Resistance trait of Fiends, or when you hit Fiend creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; <br />
-			&nbsp;&nbsp;• Giant – If your size is equal or larger than size of the Giant creature, your attacks score a critical hit on a roll of 19 or 20 against it, or if you're smaller than Giant you can go through its space and exit its range without provoking opportunity attacks, but you must end your turn in unoccupied space; <br />
-			&nbsp;&nbsp;• Humanoid – when you hit Humanoid creature, you can add a d12 to one damage roll, if attack was made with advantage; <br />
-			&nbsp;&nbsp;• Monstrosity – when Monstrosity hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that Monstrosity for the rest of the turn; <br />
-			&nbsp;&nbsp;• Ooze – you deal double fire damage to all Oozes, but resistances and immunities to fire damage still applies. Additionally, one time when Ooze creature uses its reaction to Split, you can use your reaction to attack it with advantage before it multiplies, if this attack drops creature to lower than 10 hit points Ooze wastes its reaction and is unable to Split, if not used you lose this ability after 1 hour; <br />
-			&nbsp;&nbsp;• Plant – If you deal fire damage to Plant creature that doesn't have resistance or immunity to fire damage, it has disadvantage on attack rolls and ability checks until the end of its next turn. Additionally, if your Passive Perception is higher than 10 + Plant creature's CR, you can see through its False Appearance; <br />
-			&nbsp;&nbsp;• Undead – whenever you deal critical hit to Undead creature whose CR less or equal to half your level, it is automatically destroyed, or if its CR is higher, you deal four times the damage instead of double. <br />
-			These benefits last 1 hour, unless specified otherwise.]]></description>
+			<description>You and number of your allies equal to {{secrets of the bestiary:allies}}, that can hear you, gain one benefit that you choose from the following list: &#13;
+			• Aberration – one time you fail a saving throw forced upon you by an Aberration, you can choose to succeed instead, if not used you lose this ability after 1 hour; &#13;
+			• Beast – you gain advantage on saving throws against being poisoned, knocked prone or grappled which forced upon you by a Beast creature; &#13;
+			• Celestial – your spells and magical abilities ignore Magical Resistance trait of Celestial creatures, or when you hit Celestial creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; &#13;
+			• Construct – when dealing damage to Constructs you ignore their resistances and immunities to bludgeoning, piercing, and slashing damage; &#13;
+			• Dragon – one time, whenever you fail a saving throw forced upon you by Breath (or any other Rechargeable) action of a Dragon creature, you can choose to succeed instead, if not used you lose this ability after 1 hour. Additionally, you gain advantage on saving throws against Frightful Presence; &#13;
+			• Elemental – when you deal damage to an Elemental, you ignore their resistances to acid, cold, fire, lightning, poison or thunder damage types, and you treat immunities to those types of damage as resistances; &#13;
+			• Fey – You gain advantage on any Wisdom or Intelligence saving throw forced upon you by a Fey creature; &#13;
+			• Fiend – Your spells and magical abilities ignore Magical Resistance trait of Fiends, or when you hit Fiend creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; &#13;
+			• Giant – If your size is equal or larger than size of the Giant creature, your attacks score a critical hit on a roll of 19 or 20 against it, or if you're smaller than Giant you can go through its space and exit its range without provoking opportunity attacks, but you must end your turn in unoccupied space; &#13;
+			• Humanoid – when you hit Humanoid creature, you can add a d12 to one damage roll, if attack was made with advantage; &#13;
+			• Monstrosity – when Monstrosity hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that Monstrosity for the rest of the turn; &#13;
+			• Ooze – you deal double fire damage to all Oozes, but resistances and immunities to fire damage still applies. Additionally, one time when Ooze creature uses its reaction to Split, you can use your reaction to attack it with advantage before it multiplies, if this attack drops creature to lower than 10 hit points Ooze wastes its reaction and is unable to Split, if not used you lose this ability after 1 hour; &#13;
+			• Plant – If you deal fire damage to Plant creature that doesn't have resistance or immunity to fire damage, it has disadvantage on attack rolls and ability checks until the end of its next turn. Additionally, if your Passive Perception is higher than 10 + Plant creature's CR, you can see through its False Appearance; &#13;
+			• Undead – whenever you deal critical hit to Undead creature whose CR less or equal to half your level, it is automatically destroyed, or if its CR is higher, you deal four times the damage instead of double. &#13;
+			These benefits last 1 hour, unless specified otherwise.</description>
 		</sheet>
 		<rules>
 			<stat name="secrets of the bestiary:allies" value="2" bonus="base" />

--- a/NV/bladetide-setting/realm-of-fauldis/classes/wizard-subclass-cognitivist.xml
+++ b/NV/bladetide-setting/realm-of-fauldis/classes/wizard-subclass-cognitivist.xml
@@ -4,7 +4,7 @@
 		<name>Cognitivist Subclass</name>
 		<description>Wizard who studies mind, thought and conscience.</description>
 		<author url="https://www.reddit.com/user/Nick_Vendel/">Nick Vendel</author>
-		<update version="0.0.2">
+		<update version="0.0.3">
 			<file name="wizard-subclass-cognitivist.xml" url="https://raw.githubusercontent.com/NickVendel/NV-elements/master/NV/bladetide-setting/realm-of-fauldis/classes/wizard-subclass-cognitivist.xml" />
 		</update>
 	</info>
@@ -153,23 +153,27 @@
 			<p class="indent">These benefits last 1 hour, unless specified otherwise. Once you use this ability you need to finish short or long rest, before using it again.</p>
 		</description>
 		<sheet action="1 Minute" usage="1/Rest">
-			<description>You and number of your allies equal to 2 + {{intelligence:modifier}}, that can hear you, gain one benefit that you choose from the following list: 
-			• Aberration – one time you fail a saving throw forced upon you by an Aberration, you can choose to succeed instead, if not used you lose this ability after 1 hour; 
-			• Beast – you gain advantage on saving throws against being poisoned, knocked prone or grappled which forced upon you by a Beast creature; 
-			• Celestial – your spells and magical abilities ignore Magical Resistance trait of Celestial creatures, or when you hit Celestial creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; 
-			• Construct – when dealing damage to Constructs you ignore their resistances and immunities to bludgeoning, piercing, and slashing damage; 
-			• Dragon – one time, whenever you fail a saving throw forced upon you by Breath (or any other Rechargeable) action of a Dragon creature, you can choose to succeed instead, if not used you lose this ability after 1 hour. Additionally, you gain advantage on saving throws against Frightful Presence; 
-			• Elemental – when you deal damage to an Elemental, you ignore their resistances to acid, cold, fire, lightning, poison or thunder damage types, and you treat immunities to those types of damage as resistances; 
-			• Fey – You gain advantage on any Wisdom or Intelligence saving throw forced upon you by a Fey creature; 
-			• Fiend – Your spells and magical abilities ignore Magical Resistance trait of Fiends, or when you hit Fiend creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; 
-			• Giant – If your size is equal or larger than size of the Giant creature, your attacks score a critical hit on a roll of 19 or 20 against it, or if you're smaller than Giant you can go through its space and exit its range without provoking opportunity attacks, but you must end your turn in unoccupied space; 
-			• Humanoid – when you hit Humanoid creature, you can add a d12 to one damage roll, if attack was made with advantage; 
-			Monstrosity – when Monstrosity hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that Monstrosity for the rest of the turn; 
-			• Ooze – you deal double fire damage to all Oozes, but resistances and immunities to fire damage still applies. Additionally, one time when Ooze creature uses its reaction to Split, you can use your reaction to attack it with advantage before it multiplies, if this attack drops creature to lower than 10 hit points Ooze wastes its reaction and is unable to Split, if not used you lose this ability after 1 hour; 
-			• Plant – If you deal fire damage to Plant creature that doesn't have resistance or immunity to fire damage, it has disadvantage on attack rolls and ability checks until the end of its next turn. Additionally, if your Passive Perception is higher than 10 + Plant creature's CR, you can see through its False Appearance; 
-			• Undead – whenever you deal critical hit to Undead creature whose CR less or equal to half your level, it is automatically destroyed, or if its CR is higher, you deal four times the damage instead of double. 
-			These benefits last 1 hour, unless specified otherwise.</description>
+			<description><![CDATA[You and number of your allies equal to {{secrets of the bestiary:allies}}, that can hear you, gain one benefit that you choose from the following list: <br />
+			&nbsp;&nbsp;• Aberration – one time you fail a saving throw forced upon you by an Aberration, you can choose to succeed instead, if not used you lose this ability after 1 hour; <br />
+			&nbsp;&nbsp;• Beast – you gain advantage on saving throws against being poisoned, knocked prone or grappled which forced upon you by a Beast creature; <br />
+			&nbsp;&nbsp;• Celestial – your spells and magical abilities ignore Magical Resistance trait of Celestial creatures, or when you hit Celestial creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; <br />
+			&nbsp;&nbsp;• Construct – when dealing damage to Constructs you ignore their resistances and immunities to bludgeoning, piercing, and slashing damage; <br />
+			&nbsp;&nbsp;• Dragon – one time, whenever you fail a saving throw forced upon you by Breath (or any other Rechargeable) action of a Dragon creature, you can choose to succeed instead, if not used you lose this ability after 1 hour. Additionally, you gain advantage on saving throws against Frightful Presence; <br />
+			&nbsp;&nbsp;• Elemental – when you deal damage to an Elemental, you ignore their resistances to acid, cold, fire, lightning, poison or thunder damage types, and you treat immunities to those types of damage as resistances; <br />
+			&nbsp;&nbsp;• Fey – You gain advantage on any Wisdom or Intelligence saving throw forced upon you by a Fey creature; <br />
+			&nbsp;&nbsp;• Fiend – Your spells and magical abilities ignore Magical Resistance trait of Fiends, or when you hit Fiend creature that doesn't have this trait with a spell, magical ability or magical attack, you can add a d8 to one damage roll; <br />
+			&nbsp;&nbsp;• Giant – If your size is equal or larger than size of the Giant creature, your attacks score a critical hit on a roll of 19 or 20 against it, or if you're smaller than Giant you can go through its space and exit its range without provoking opportunity attacks, but you must end your turn in unoccupied space; <br />
+			&nbsp;&nbsp;• Humanoid – when you hit Humanoid creature, you can add a d12 to one damage roll, if attack was made with advantage; <br />
+			&nbsp;&nbsp;• Monstrosity – when Monstrosity hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that Monstrosity for the rest of the turn; <br />
+			&nbsp;&nbsp;• Ooze – you deal double fire damage to all Oozes, but resistances and immunities to fire damage still applies. Additionally, one time when Ooze creature uses its reaction to Split, you can use your reaction to attack it with advantage before it multiplies, if this attack drops creature to lower than 10 hit points Ooze wastes its reaction and is unable to Split, if not used you lose this ability after 1 hour; <br />
+			&nbsp;&nbsp;• Plant – If you deal fire damage to Plant creature that doesn't have resistance or immunity to fire damage, it has disadvantage on attack rolls and ability checks until the end of its next turn. Additionally, if your Passive Perception is higher than 10 + Plant creature's CR, you can see through its False Appearance; <br />
+			&nbsp;&nbsp;• Undead – whenever you deal critical hit to Undead creature whose CR less or equal to half your level, it is automatically destroyed, or if its CR is higher, you deal four times the damage instead of double. <br />
+			These benefits last 1 hour, unless specified otherwise.]]></description>
 		</sheet>
+		<rules>
+			<stat name="secrets of the bestiary:allies" value="2" bonus="base" />
+			<stat name="secrets of the bestiary:allies" value="intelligence:modifier" />
+		</rules>
 	</element>
 	<element name="One in a Million" type="Archetype Feature" source="Bladetide: Realm of Fauldis" id="ID_NV_FLDS_WIZARD_SUBCLASS_COGNITIVIST_ONE_IN_A_MILLION">
 		<description>


### PR DESCRIPTION
CFV include:
• **Shadewoods Circle Spells** enhancement for Circle Spells of Circle of the Land Druid.
• **Artifact Researcher** replacement for Polyglot feature of Cognitivist Wizard.

Cognitivist Fix:
sheet description for Secrets of the Bestiary feature now includes ~~CDATA~~ `&#13;` in hopes that it will help break lines.